### PR TITLE
Added utils.verifyRaw and .verifyFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Via [npm](http://npmjs.org/):
 ```bash
 $ npm install -g htpasswd
 ```	
-## Usage
+## Command line usage
 
 ```bash
 $ htpasswd [-cimpsDv] passwordfile username
@@ -26,15 +26,32 @@ $ htpasswd -n[imps] username
 $ htpasswd -nb[mps] username password
 ```	
 
+## Script usage
+```
+var htpasswd = require("htpasswd");
+
+// Verifies that the hash corresponds to the password
+htpasswd.verify("$apr1$esYVbnli$quFMF4h/3XrNnHl08RYKc.", "root"); // Returns true, because "$apr1$es..." is the hash of "root"
+
+// SYNCHRONOUSLY verifies that the user "root" has password "root" in the file ".htpasswd"
+htpasswd.verifyFile(".htpasswd", "root", "root"); // Returns either "Password for user root correct." or "Password verification failed."
+
+// Asynchronous version
+require("fs").readFile(".htpasswd", {encoding:"UTF8"} function(err, contents) {
+    if (err) throw err;
+    htpasswd.verifyRaw(contents, "root", "root"); // Returns either "Password for user root correct." or "Password verification failed."
+});
+```
+
 ## Options
 
  - `-b` - Use the password from the command line rather than prompting for it. This option should be used with extreme care, since the password is clearly visible on the command line. For script use see the -i option.
  - `-i` - Read the password from stdin without verification (for script usage).
  - `-c` - Create a new file.
  - `-n` - Don't update file; display results on stdout.
- - `-m` - Use MD5 encryption for passwords. This is the default.
+ - `-m` - Use MD5 for passwords. This is the default.
  - `-d` - Use crypt() encryption for passwords. This algorithm limits the password length to 8 characters. This algorithm is insecure by today's standards.
- - `-s` - Use SHA encryption for passwords. This algorithm is insecure by today's standards.
+ - `-s` - Use SHA for passwords. This algorithm is insecure by today's standards.
  - `-p` - Do not encrypt the password (plaintext).
  - `-D` - Delete the specified user.
  - `-v` - Verify password. Verify that the given password matches the password of the user stored in the specified htpasswd file.

--- a/src/htpasswd.coffee
+++ b/src/htpasswd.coffee
@@ -8,3 +8,5 @@ if (typeof htpasswd_is_program) != "undefined"
 else
   # Exporting verify method.
   module.exports.verify = require('./utils').verify
+  module.exports.verifyRaw = require('./utils').verifyRaw
+  module.exports.verifyFile = require('./utils').verifyFile

--- a/src/processor.coffee
+++ b/src/processor.coffee
@@ -37,7 +37,7 @@ module.exports =
     prompt.get options, (err, result) ->
       if not err and result.password is result.rePassword
         program.args.push result.password
-        module.exports.finalize program
+        console.log module.exports.finalize program
       else
         console.error "\nPassword verification error."
 
@@ -52,7 +52,10 @@ module.exports =
     # Finished reading.
     process.stdin.on 'end', () ->
       program.args.push password
-      module.exports.finalize program
+      try
+        console.log module.exports.syncFile program
+      catch error
+        console.error error.message
 
 # Processing command.
   process: (program) ->
@@ -73,14 +76,22 @@ module.exports =
       hash = utils.encode program
       # Print to stdout.
       console.log "#{username}:#{hash}"
-    else       
+    else
       try
-        module.exports.syncFile program
+        console.log module.exports.syncFile program
       catch error
         console.error error.message
         
   # Sync file with new data.
   syncFile: (program) ->
+    if not program.args
+      program.args = []
+    if program.passwordFile
+      program.args[0] = program.passwordFile
+    if program.username
+      program.args[1] = program.username
+    if program.password
+      program.args[2] = program.password
     passwordFile = program.args[0]
     username = program.args[1]
     password = program.args[2]
@@ -90,11 +101,15 @@ module.exports =
     newLines = []
 
     if not program.create
-      if not fs.existsSync passwordFile
-        console.error "Cannot modify file #{passwordFile}; use '-c' to create it."
-        return
-        
-      lines = (fs.readFileSync passwordFile, 'UTF-8').split "\n"
+      if not program.raw
+        if not fs.existsSync passwordFile
+          throw new Error "Cannot modify file #{passwordFile}; use '-c' to create it."
+          
+        lines = (fs.readFileSync passwordFile, 'UTF-8')
+      else
+        lines = program.raw
+
+      lines = lines.split "\n"
       
       for line, i in lines
         if (line.indexOf "#{username}:") is 0
@@ -105,24 +120,26 @@ module.exports =
             [username, hash] = line.split ":"
 
             if (utils.verify hash, password)
-              console.log "Password for user #{username} correct."
+              status = "Password for user #{username} correct."
             else
-              console.log "Password verification failed."
+              status = "Password verification failed."
           else if program.delete # Deletion case.
-            console.log "Deleting password for user #{username}."
+            status = "Deleting password for user #{username}."
           else # Updating password.      
             newLines.push "#{username}:#{hash}"
-            console.log "Updating password for user #{username}."
+            status = "Updating password for user #{username}."
         else if line # Remove empty lines.
           newLines.push line
 
     if not program.verify
       if not found # Adding user to existing file.
         if program.delete
-          console.error "User #{username} not found."
+          throw new Error "User #{username} not found."
         else
           newLines.push "#{username}:#{hash}"
-          console.log "Adding password for user #{username}."
+          status = "Adding password for user #{username}."
 
       # Write data.
       fs.writeFileSync passwordFile, (newLines.join "\n") + "\n", 'UTF-8'
+
+    return status;

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -30,6 +30,24 @@ module.exports =
     else
       (hash is password) or ((module.exports.crypt3 password, hash) is hash)
 
+    # Verifies if user and password are correct, from a raw htpasswd string
+  verifyRaw: (raw, username, password) ->
+    return require('./processor').syncFile({
+      raw: raw,
+      username: username,
+      password: password,
+      verify: true
+    })
+
+  # Verifies if user and password are correct, from a htpasswd file
+  verifyFile: (file, username, password) ->
+    return require('./processor').syncFile({
+      passwordFile: file,
+      username: username,
+      password: password,
+      verify: true
+    })
+
   # Encodes password hash for output.
   encode: (program) ->
     if not program.delete


### PR DESCRIPTION
I added utils.verifyFile and .verifyRaw, so that htpasswd can be used more easily in a script. They are essentially htpasswd --batch --verify, the former taking a string and the latter taking a filename.